### PR TITLE
fix: setup release workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @catalystcommunity/Core

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,47 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  validate-pr-title:
+    name: Validate Conventional Commits PR
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: crazy-max/ghaction-dump-context@v1
+      - uses: amannn/action-semantic-pull-request@v3.4.6
+        with:
+          types: |
+            fix
+            feat
+            norelease
+          validateSingleCommit: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+  test:
+    if: github.event.pull_request.draft == false
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          # In order:
+          # * go Module download cache
+          # * go Build cache (Linux)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: Compile
+        run: |
+          go build ./...

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+name: Release
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    name: Release
+    steps:
+      - uses: catalystcommunity/action-semantic-release-general@v1
+        with:
+          token: ${{ secrets.AUTOMATION_PAT }}


### PR DESCRIPTION
copied release workflows from another go library repository on catalystcommunity. this should trigger a new release and give us a v1.0 that we can update `go-notifications` to reference.